### PR TITLE
fix(readme): correct Quarto template path for Linux compatibility

### DIFF
--- a/quarto/nmfs-slides/README.md
+++ b/quarto/nmfs-slides/README.md
@@ -3,7 +3,7 @@
 ## Installing
 
 ```bash
-quarto use template nmfs-opensci/noaa-nmfs-brand-resources/quarto/nmfs-slides
+quarto use template nmfs-opensci/NOAA-NMFS-Brand-Resources/quarto/nmfs-slides
 ```
 
 This will install the extension and create an example qmd file that you can use as a starting place for your slide deck.


### PR DESCRIPTION
This PR addresses issue #16

The installation command has been updated to use the correct case, which ensures the Quarto slides extension installs successfully on Linux systems. 